### PR TITLE
Re-do CVR handling to allow for different retrieval methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ processed_pnrs.csv
 smiley_json.json
 smiley_json_processed.json
 smiley_xml.xml
+config.ini

--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # Smiley data handler
 
+## Configuration
+
+First copy `config.sample.ini` to `config.ini`, then fill out the missing fields.
+
+- `[cvr]`
+    - `provider`, valid choices: `[ cvrapi | virk | scrape ]`
+        - `cvrapi`, request data from [cvrapi](https://cvrapi.dk/)
+            - no limit, no delay
+            - requires `[cvrapi]`
+        - `virk`, TBA - virk API
+        - `scrape`, scrape from [Virk CVR data](https://datacvr.virk.dk/data/)
+            - 10s delay
+- `[cvrapi]`
+    - `api_key`, API key for [cvrapi](https://cvrapi.dk/)
+
 ## Running
 To run
 ```shell

--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ class FilterXMLConfig:
 
     @classmethod
     def iso_fmt(cls):
-        return cls.open_config().get('misc', 'iso_fmt')
+        return '%Y-%m-%dT%H:%M:%SZ'
 
     @classmethod
     def cvr_provider(cls):

--- a/config.py
+++ b/config.py
@@ -1,0 +1,22 @@
+from configparser import ConfigParser
+
+
+class FilterXMLConfig:
+
+    @classmethod
+    def open_config(cls) -> ConfigParser:
+        cfg = ConfigParser()
+        cfg.read('config.ini')
+        return cfg
+
+    @classmethod
+    def iso_fmt(cls):
+        return cls.open_config().get('misc', 'iso_fmt')
+
+    @classmethod
+    def cvr_provider(cls):
+        return cls.open_config().get('cvr', 'provider')
+
+    @classmethod
+    def cvrapi_api_key(cls):
+        return cls.open_config().get('cvrapi', 'api_key')

--- a/config.sample.ini
+++ b/config.sample.ini
@@ -1,0 +1,5 @@
+[cvr]
+provider=
+
+[cvrapi]
+api_key=

--- a/config.sample.ini
+++ b/config.sample.ini
@@ -1,6 +1,3 @@
-[misc]
-iso_fmt=%Y-%m-%dT%H:%M:%SZ
-
 [cvr]
 provider=
 

--- a/config.sample.ini
+++ b/config.sample.ini
@@ -1,3 +1,6 @@
+[misc]
+iso_fmt=%Y-%m-%dT%H:%M:%SZ
+
 [cvr]
 provider=
 

--- a/cvr.py
+++ b/cvr.py
@@ -86,8 +86,11 @@ class CVRHandlerCVRAPI(CVRHandlerBase):
             'country': 'dk',
             'token': FilterXMLConfig.cvrapi_api_key()
         }
+        headers = {
+            'User-Agent': 'sw814f21 - FindSmiley app - Jonas Andersen'
+        }
 
-        res = get(self.URL, params=params)
+        res = get(self.URL, params=params, headers=headers)
         content = json.loads(res.content.decode('utf-8'))
 
         if content:

--- a/cvr.py
+++ b/cvr.py
@@ -1,0 +1,40 @@
+
+
+class CVRHandlerBase:
+    URL = ''
+
+    def append_data(self):
+        pass
+
+
+class CVRHandlerVirk(CVRHandlerBase):
+    URL = ''
+
+    def append_data(self):
+        pass
+
+
+class CVRHandlerCVRAPI(CVRHandlerBase):
+    URL = ''
+
+    def append_data(self):
+        pass
+
+
+class CVRHandlerScrape(CVRHandlerBase):
+    URL = ''
+
+    def append_data(self):
+        pass
+
+
+def get_cvr_handler(provider: str) -> CVRHandlerBase:
+    if provider == 'cvrapi':
+        return CVRHandlerCVRAPI()
+    elif provider == 'virk':
+        return CVRHandlerVirk()
+    elif provider == 'scrape':
+        return CVRHandlerScrape()
+    else:
+        raise KeyError(f'provider \"{provider}\" is invalid, please choose one of '
+                       f'[ cvrapi | virk | scrape ]')

--- a/cvr.py
+++ b/cvr.py
@@ -8,6 +8,8 @@ from config import FilterXMLConfig
 
 class CVRHandlerBase:
     URL = ''
+    SHOULD_SLEEP = False
+    CRAWL_DELAY = 0
 
     def __init__(self):
         self.appenders = [getattr(self.__class__, fun)
@@ -114,10 +116,11 @@ class CVRHandlerCVRAPI(CVRHandlerBase):
 
 class CVRHandlerScrape(CVRHandlerBase):
     URL = 'https://datacvr.virk.dk/data/visenhed'
+    SHOULD_SLEEP = True
+    CRAWL_DELAY = 10
 
     def __init__(self):
         super().__init__()
-        print(self.appenders)
 
     def collect_data(self, data: dict):
         print('-' * 40)

--- a/cvr.py
+++ b/cvr.py
@@ -1,34 +1,158 @@
+from requests import get
+from bs4 import BeautifulSoup
+from datetime import datetime
+from config import FilterXMLConfig
 
 
 class CVRHandlerBase:
     URL = ''
 
-    def append_data(self):
-        pass
+    def __init__(self):
+        self.appenders = [getattr(self.__class__, fun)
+                          for fun in dir(self.__class__)
+                          if callable(getattr(self.__class__, fun))
+                          and fun.startswith('append_')]
+        self.smiley_appenders = [getattr(self.__class__, fun)
+                                 for fun in dir(self.__class__)
+                                 if callable(getattr(self.__class__, fun))
+                                 and fun.startswith('findsmiley_')]
+
+    def collect_data(self, data: dict):
+        smiley = get(data['URL'])
+        smiley_soup = BeautifulSoup(smiley.content.decode('utf-8'), 'html.parser')
+
+        for appender in self.smiley_appenders:
+            data = appender(smiley_soup, data)
+
+        return data
+
+    @staticmethod
+    def findsmiley_append_reports(soup, row):
+        tags = soup.findAll('a', attrs={'target': '_blank'})
+        keys = ['seneste_kontrol', 'naestseneste_kontrol', 'tredjeseneste_kontrol',
+                'fjerdeseneste_kontrol']
+        reports = []
+
+        # we assume that pdfs will continue to appear in descending order
+        # if we want safe guarding against changes in order we can use
+        # date = t.find('p', attrs={'class': 'DateText'}).text
+        # and check the date against the fields of param: row
+        for tag, key in zip(tags, keys):
+            if row[key]:
+                url = tag.attrs['href']
+                date = datetime.strptime(
+                    row[f'{key}_dato'],
+                    '%d-%m-%Y %H:%M:%S'
+                )
+
+                d = {
+                    'report_id': url.split('?')[1],
+                    'smiley': row[key],
+                    'date': date.strftime(FilterXMLConfig.iso_fmt())
+                }
+
+                reports.append(d)
+
+                del row[key]
+                del row[f'{key}_dato']
+
+        row['smiley_reports'] = reports
+
+        return row
 
 
 class CVRHandlerVirk(CVRHandlerBase):
     URL = ''
 
-    def append_data(self):
-        pass
+    def __init__(self):
+        super().__init__()
+
+    def collect_data(self, data: dict):
+        raise NotImplementedError(f'{self.__class__} not yet implemented')
 
 
 class CVRHandlerCVRAPI(CVRHandlerBase):
-    URL = ''
+    URL = 'https://cvrapi.dk/api'
 
-    def append_data(self):
-        pass
+    def __init__(self):
+        super().__init__()
+
+    def collect_data(self, data: dict):
+
+        return super().collect_data(data)
 
 
 class CVRHandlerScrape(CVRHandlerBase):
-    URL = ''
+    URL = 'https://datacvr.virk.dk/data/visenhed'
 
-    def append_data(self):
-        pass
+    def __init__(self):
+        super().__init__()
+        print(self.appenders)
+
+    def collect_data(self, data: dict):
+        print('-' * 40)
+        print(f'{data["navn1"]} | {data["pnr"]}')
+        params = {
+            'enhedstype': 'produktionsenhed',
+            'id': data['pnr'],
+            'language': 'da',
+            'soeg': data['pnr'],
+        }
+
+        print(f'{self.URL} | {params}')
+        res = get(self.URL, params=params)
+        soup = BeautifulSoup(res.content.decode('utf-8'), 'html.parser')
+
+        for appender in self.appenders:
+            data = appender(soup, data)
+
+        return super().collect_data(data)
+
+    @staticmethod
+    def append_cvr_industry_code(soup, row):
+        """
+        Appends industry code and text from datacvr.virk.dk to a row
+        """
+        industry_elem = soup.find(
+            'div', attrs={'class': 'Help-stamdata-data-branchekode'})
+        if industry_elem:
+            industry_elem = industry_elem.parent.parent.parent
+            industry = list(industry_elem.children)[3].text.strip()
+            row['industry_code'] = industry.split()[0]
+            row['industry_text'] = industry.replace(
+                row['industry_code'], '').strip()
+            print(f'code: {row["industry_code"]}: {row["industry_text"]}')
+        else:
+            row['industry_code'] = row['industry_text'] = None
+        return row
+
+    @staticmethod
+    def append_cvr_start_date(soup, row):
+        """
+        Appends start date from datacvr.virk.dk to a row
+        """
+        start_date_elem = soup.find(
+            'div', attrs={'class': 'Help-stamdata-data-startdato'})
+        if start_date_elem:
+            start_date_elem = start_date_elem.parent.parent.parent
+            date = datetime.strptime(
+                list(start_date_elem.children)[3].text.strip(),
+                '%d.%m.%Y'
+            )
+            row['start_date'] = date.strftime(FilterXMLConfig.iso_fmt())
+            print(f'date: {row["start_date"]}')
+        else:
+            row['industry_code'] = row['industry_text'] = None
+
+        del row['branche']
+        del row['brancheKode']
+
+        return row
 
 
-def get_cvr_handler(provider: str) -> CVRHandlerBase:
+def get_cvr_handler() -> CVRHandlerBase:
+    provider = FilterXMLConfig.cvr_provider()
+
     if provider == 'cvrapi':
         return CVRHandlerCVRAPI()
     elif provider == 'virk':

--- a/cvr.py
+++ b/cvr.py
@@ -16,10 +16,7 @@ class CVRHandlerBase:
                           for fun in dir(self.__class__)
                           if callable(getattr(self.__class__, fun))
                           and fun.startswith('append_')]
-        self.smiley_appenders = [getattr(self.__class__, fun)
-                                 for fun in dir(self.__class__)
-                                 if callable(getattr(self.__class__, fun))
-                                 and fun.startswith('findsmiley_')]
+        self.smiley_appenders = [self.findsmiley_append_reports]
 
     def collect_data(self, data: dict):
         smiley = get(data['URL'])

--- a/data_handler.py
+++ b/data_handler.py
@@ -226,15 +226,19 @@ class DataHandler(BaseDataHandler):
         """
         Filters all companies that have not yet received a smiley control visit.
         """
-        return 'seneste_kontrol' in data.keys() and data['seneste_kontrol'] is not None
+        res = 'smiley_reports' in data.keys() and len(data['smiley_reports']) > 0
+        print(f'null control: {res}')
+        return res
 
     @ staticmethod
     def filter_null_coordinates(data: dict):
         """
         Filters all companies without a longitude or latitude.
         """
-        return 'Geo_Lat' in data.keys() and data['Geo_Lat'] is not None \
-               and 'Geo_Lng' in data.keys() and data['Geo_Lng'] is not None
+        res = 'Geo_Lat' in data.keys() and data['Geo_Lat'] is not None \
+              and 'Geo_Lng' in data.keys() and data['Geo_Lng'] is not None
+        print(f'null coords: {res}')
+        return res
 
     @ staticmethod
     def _filter_dead_companies(data: dict):

--- a/data_handler.py
+++ b/data_handler.py
@@ -4,10 +4,8 @@ import time
 from temp_file import TempFile
 from prev_processed_file import PrevProcessedFile
 from requests import get
-from bs4 import BeautifulSoup
 from xml.etree import ElementTree as ET
 from datetime import datetime
-from config import FilterXMLConfig
 from cvr import get_cvr_handler
 
 
@@ -158,20 +156,12 @@ class BaseDataHandler:
     def valid_production_unit(self, restaurant: dict) -> bool:
         return self._has_pnr(restaurant) and self._has_cvr(restaurant)
 
-    def _filter_data(self, data: list) -> list:
-        """
-        Apply filters
-        """
-        for _filter in self.filters:
-            data = _filter(data)
-
-        return data
-
     def _should_keep(self, data: dict) -> bool:
         """
         Apply filters to see if row should be kept in result
         """
-        res = []
+        res = [_filter(data) for _filter in self.filters]
+        return all(res)
 
     @ staticmethod
     def _has_cvr(row: dict):

--- a/data_handler.py
+++ b/data_handler.py
@@ -5,7 +5,6 @@ from temp_file import TempFile
 from prev_processed_file import PrevProcessedFile
 from requests import get
 from xml.etree import ElementTree as ET
-from datetime import datetime
 from cvr import get_cvr_handler
 
 
@@ -63,11 +62,13 @@ class BaseDataHandler:
         with open(self.SMILEY_JSON, 'w') as f:
             f.write(json.dumps(res, indent=4, sort_keys=True))
 
-    def convert_to_int(self, data: dict, *keys):
+    @staticmethod
+    def convert_to_int(data: dict, *keys):
         for k in keys:
             data[k] = int(data[k]) if data[k] is not None else None
 
-    def convert_to_float(self, data: dict, *keys):
+    @staticmethod
+    def convert_to_float(data: dict, *keys):
         for k in keys:
             data[k] = float(data[k]) if data[k] is not None else None
 
@@ -91,7 +92,7 @@ class BaseDataHandler:
             Includes only production units
             Applies filters and appends from DataHandler
         """
-        out_path = f'smiley_json_processed.json'
+        out_path = 'smiley_json_processed.json'
 
         with open(self.SMILEY_JSON, 'r') as f:
             d = json.loads(f.read())

--- a/data_handler.py
+++ b/data_handler.py
@@ -215,12 +215,14 @@ class DataHandler(BaseDataHandler):
         super().__init__(*args, **kwargs)
 
     @ staticmethod
-    def _filter_industry_codes(data: dict):
+    def filter_industry_codes(data: dict):
         """
         Filters all companies that do not have a valid industry code.
         """
         include_codes = ['561010', '561020', '563000']
-        return 'industry_code' in data.keys() and data['industry_code'] in include_codes
+        res = 'industry_code' in data.keys() and data['industry_code'] in include_codes
+        print(f'valid industry code: {res}')
+        return res
 
     @ staticmethod
     def filter_null_control(data: dict):
@@ -228,7 +230,7 @@ class DataHandler(BaseDataHandler):
         Filters all companies that have not yet received a smiley control visit.
         """
         res = 'smiley_reports' in data.keys() and len(data['smiley_reports']) > 0
-        print(f'null control: {res}')
+        print(f'control not null: {res}')
         return res
 
     @ staticmethod
@@ -238,20 +240,5 @@ class DataHandler(BaseDataHandler):
         """
         res = 'Geo_Lat' in data.keys() and data['Geo_Lat'] is not None \
               and 'Geo_Lng' in data.keys() and data['Geo_Lng'] is not None
-        print(f'null coords: {res}')
+        print(f'coords not null: {res}')
         return res
-
-    @ staticmethod
-    def _filter_dead_companies(data: dict):
-        """
-        Excluded for now. Remove leading underscore to include.
-
-        Filters all companies that are presumed dead - i.e., has not received a smiley control visit
-        within the last year.
-        """
-        last_control = datetime.strptime(
-            data['seneste_kontrol_dato'], '%d-%m-%Y %H:%M:%S')
-        now = datetime.now()
-        diff = now - last_control
-
-        return diff.days < 365

--- a/data_handler.py
+++ b/data_handler.py
@@ -18,10 +18,6 @@ class BaseDataHandler:
     SMILEY_XML = 'smiley_xml.xml'
     SMILEY_JSON = 'smiley_json.json'
 
-    CRAWL_DELAY = 10
-    BASE_CVR_URL = 'https://datacvr.virk.dk/data/'
-    CRAWL_CVR_URL = f'{BASE_CVR_URL}visenhed'
-
     def __init__(self, *args, **kwargs):
         self._sample_size = kwargs.pop('sample', 0)
         self._skip_scrape = kwargs.pop('no_scrape', False)

--- a/data_handler.py
+++ b/data_handler.py
@@ -224,50 +224,39 @@ class DataHandler(BaseDataHandler):
         super().__init__(*args, **kwargs)
 
     @ staticmethod
-    def _filter_industry_codes(data):
+    def _filter_industry_codes(data: dict):
         """
         Filters all companies that do not have a valid industry code.
         """
         include_codes = ['561010', '561020', '563000']
-        return [item
-                for item in data
-                if 'industry_code' in item.keys()
-                and item['industry_code'] in include_codes]
+        return 'industry_code' in data.keys() and data['industry_code'] in include_codes
 
     @ staticmethod
-    def filter_null_control(data):
+    def filter_null_control(data: dict):
         """
         Filters all companies that have not yet received a smiley control visit.
         """
-        return [item
-                for item in data
-                if 'seneste_kontrol' in item.keys()
-                and item['seneste_kontrol'] is not None]
+        return 'seneste_kontrol' in data.keys() and data['seneste_kontrol'] is not None
 
     @ staticmethod
-    def filter_null_coordinates(data):
+    def filter_null_coordinates(data: dict):
         """
         Filters all companies without a longitude or latitude.
         """
-        return [item
-                for item in data
-                if item['Geo_Lat'] is not None and item['Geo_Lng'] is not None]
+        return 'Geo_Lat' in data.keys() and data['Geo_Lat'] is not None \
+               and 'Geo_Lng' in data.keys() and data['Geo_Lng'] is not None
 
     @ staticmethod
-    def _filter_dead_companies(data):
+    def _filter_dead_companies(data: dict):
         """
         Excluded for now. Remove leading underscore to include.
 
         Filters all companies that are presumed dead - i.e., has not received a smiley control visit
         within the last year.
         """
-        res = []
-        for item in data:
-            last_control = datetime.strptime(
-                item['seneste_kontrol_dato'], '%d-%m-%Y %H:%M:%S')
-            now = datetime.now()
-            diff = now - last_control
+        last_control = datetime.strptime(
+            data['seneste_kontrol_dato'], '%d-%m-%Y %H:%M:%S')
+        now = datetime.now()
+        diff = now - last_control
 
-            if diff.days < 365:
-                res.append(item)
-        return res
+        return diff.days < 365

--- a/data_handler.py
+++ b/data_handler.py
@@ -7,9 +7,8 @@ from requests import get
 from bs4 import BeautifulSoup
 from xml.etree import ElementTree as ET
 from datetime import datetime
-
-
-ISO8601_FMT = '%Y-%m-%dT%H:%M:%SZ'
+from config import FilterXMLConfig
+from cvr import get_cvr_handler
 
 
 class BaseDataHandler:
@@ -29,6 +28,8 @@ class BaseDataHandler:
     def __init__(self, *args, **kwargs):
         self._sample_size = kwargs.pop('sample', 0)
         self._skip_scrape = kwargs.pop('no_scrape', False)
+
+        self.cvr_handler = get_cvr_handler()
 
         self.filters = [getattr(self.__class__, fun)
                         for fun in dir(self.__class__)
@@ -267,7 +268,7 @@ class DataHandler(BaseDataHandler):
                 list(start_date_elem.children)[3].text.strip(),
                 '%d.%m.%Y'
             )
-            row['start_date'] = date.strftime(ISO8601_FMT)
+            row['start_date'] = date.strftime(FilterXMLConfig.iso_fmt())
             print(f'date: {row["start_date"]}')
         else:
             row['industry_code'] = row['industry_text'] = None
@@ -299,7 +300,7 @@ class DataHandler(BaseDataHandler):
                 d = {
                     'report_id': url.split('?')[1],
                     'smiley': row[key],
-                    'date': date.strftime(ISO8601_FMT)
+                    'date': date.strftime(FilterXMLConfig.iso_fmt())
                 }
 
                 reports.append(d)

--- a/data_handler.py
+++ b/data_handler.py
@@ -102,6 +102,7 @@ class BaseDataHandler:
 
         res = temp_file.get_all()
         total_rows = len(d)
+        row_index = 0
 
         for restaurant in d:
             # we use this to avoid using the same fallback in three separate if statements
@@ -120,9 +121,7 @@ class BaseDataHandler:
                         and prev_processed.should_process_restaurant(restaurant):
 
                     # only sleep if --no-scrape is not passed, and if our cvr provider requests it.
-                    # we sleep before processing the next so we avoid sleeping after the last
-                    # row has been processed
-                    if not self._skip_scrape and self.cvr_handler.SHOULD_SLEEP:
+                    if not self._skip_scrape and self.cvr_handler.SHOULD_SLEEP and row_index > 0:
                         time.sleep(self.cvr_handler.CRAWL_DELAY)
 
                     # only collect data if we haven't passed --no-scrape
@@ -144,6 +143,8 @@ class BaseDataHandler:
                 print(f'Collected {len(res)} of {self._sample_size} samples')
             else:
                 print(f'{total_rows - len(res)} rows to go')
+
+            row_index += 1
 
         prev_processed.output_processed_companies(res)
         temp_file.close()

--- a/data_handler.py
+++ b/data_handler.py
@@ -106,7 +106,7 @@ class BaseDataHandler:
             row_kept = False
 
             # if sample size CLI arg is supplied, stop when its reached
-            if self._sample_size and len(res) == self._sample_size:
+            if self._sample_size and len(res) >= self._sample_size:
                 break
 
             # first check if the restaurant is valid

--- a/prev_processed_file.py
+++ b/prev_processed_file.py
@@ -26,7 +26,9 @@ class PrevProcessedFile:
                 writer.writerow(
                     {'pnr': pnr, 'seneste_kontrol_dato': control_date})
 
-    def should_process_restaurant(self, pnr: str, control_date: str):
+    def should_process_restaurant(self, restaurant: dict):
+        pnr = restaurant['pnr']
+        control_date = restaurant['seneste_kontrol_dato']
         prev_processed_restaurant = self.get_by_pnr(pnr)
         if prev_processed_restaurant:
             if self.__is_control_newer(control_date, prev_processed_restaurant):


### PR DESCRIPTION
This PR became a bit more comprehensive and broad than expected (sorry not sorry.)

The primary purpose of this PR is to abstract the CVR data retrieval so as to allow easily changing between different methods. Currently we can choose between `scrape` (scraping from Virk) and `cvrapi` (json requests from cvrapi.dk). I also set up for `virk` (elastic search for Virk) once (if) we get access to that. This selection is done in `config.ini` - see `README.md` for more info.

Changes:
- all CVR data handling has been moved to `cvr.py`
    - a base class that handles scraping from findsmiley.dk
    - three subclasses, one for each of: Virk scraping; Virk elastic search; cvrapi.dk requests
- added a `config.ini` file that handles CVR provider and relevant config for that
    - this config is handled in `config.py`
- it was necessary to restructure the entire flow in `_process_smiley_json()`, which means that
    - `--sample n / -s n` CLI arg actually works as intended
    - `filter_`s now only work on one row and are applied during the main loop through `_should_keep()`