### PR TITLE
Revamp data outputter

### DIFF
--- a/filter_xml/data_outputter.py
+++ b/filter_xml/data_outputter.py
@@ -3,21 +3,48 @@ import requests
 from typing import Union
 
 
-class BaseDataOutputter:
+class _BaseDataOutputter:
     """
         An abstract class that is used to define different output strategies
     """
 
-    def write(self, data_to_write: Union[dict, list]) -> None:
+    def get(self) -> list:
         """
-            An abstract method that takes in some data that should be outputtet as a dictionary
+        Abstract implementation of method for retrieving a list of all restaurants
 
-            Different implementations will then save this data in different places
+        Should be overridden in inherited classes
         """
-        pass
+        raise NotImplementedError('Method called on base class; use inherited')
+
+    def insert(self, data: Union[dict, list], token: int) -> None:
+        """
+        Abstract implementation of method for sending a list of restaurants that should be
+        inserted to the API
+
+        Should be overridden in inherited classes
+        """
+        raise NotImplementedError('Method called on base class; use inherited')
+
+    def update(self, data: Union[dict, list], token: int) -> None:
+        """
+        Abstract implementation of method for sending a list of restaurants that should be
+        updated to the API
+
+        Should be overridden in inherited classes
+        """
+        raise NotImplementedError('Method called on base class; use inherited')
+
+    def delete(self, data: Union[dict, list], token: int) -> None:
+        """
+        Abstract implementation of method for sending a list of restaurants that should be
+        deleted to the API
+
+        Should be overridden in inherited classes
+        """
+        raise NotImplementedError('Method called on base class; use inherited')
 
 
-class FileOutputter(BaseDataOutputter):
+class FileOutputter(_BaseDataOutputter):
     def __init__(self):
         self.file_path = 'smiley_json_processed.json'
 
@@ -29,7 +56,7 @@ class FileOutputter(BaseDataOutputter):
             f.write(json.dumps(data_to_write, indent=4))
 
 
-class DatabaseOutputter(BaseDataOutputter):
+class DatabaseOutputter(_BaseDataOutputter):
     endpoint = 'https://127.0.0.1/admin/insert'
 
     def write(self, data: Union[dict, list]) -> None:
@@ -43,7 +70,7 @@ class DatabaseOutputter(BaseDataOutputter):
             FileOutputter().write(data)
 
 
-def get_outputter(should_send_to_db: bool) -> BaseDataOutputter:
+def get_outputter(should_send_to_db: bool) -> _BaseDataOutputter:
     """
         A helper method used to pick which outputter should be used
     """

--- a/filter_xml/data_outputter.py
+++ b/filter_xml/data_outputter.py
@@ -1,5 +1,6 @@
 import json
 import requests
+from requests.exceptions import ConnectionError
 from typing import Union
 
 
@@ -106,8 +107,13 @@ class DatabaseOutputter(_BaseDataOutputter):
         """
         Retrieve all current restaurants from the API
         """
-        res = requests.get(self.ENDPOINT)
-        return json.loads(res.content.decode('utf-8'))
+        try:
+            res = requests.get(self.ENDPOINT, timeout=4)
+            if res.status_code == 200:
+                return json.loads(res.content.decode('utf-8'))
+        except ConnectionError:
+            print('Failed to connect to API')
+        return []
 
     def insert(self, data: Union[dict, list], token: str) -> None:
         """

--- a/filter_xml/data_outputter.py
+++ b/filter_xml/data_outputter.py
@@ -63,7 +63,7 @@ class FileOutputter(_BaseDataOutputter):
         """
         Retrieve sample restaurants from file
         """
-        raise NotImplementedError('Method not implemented for FileOutputter')
+        return DatabaseOutputter().get()
 
     def insert(self, data: Union[dict, list], token: int) -> None:
         """
@@ -73,7 +73,7 @@ class FileOutputter(_BaseDataOutputter):
         :param token: an identifier for the current session, to ensure that separate
                       POST / PUT / DELETE requests are recognized as a single version of data
         """
-        with open(f'{self.FILE_BASE}PUT.json', 'w') as f:
+        with open(f'{self.FILE_BASE}insert.json', 'w') as f:
             f.write(json.dumps(data, indent=4))
 
     def update(self, data: Union[dict, list], token: int) -> None:
@@ -84,7 +84,7 @@ class FileOutputter(_BaseDataOutputter):
         :param token: an identifier for the current session, to ensure that separate
                       POST / PUT / DELETE requests are recognized as a single version of data
         """
-        with open(f'{self.FILE_BASE}POST.json', 'w') as f:
+        with open(f'{self.FILE_BASE}update.json', 'w') as f:
             f.write(json.dumps(data, indent=4))
 
     def delete(self, data: Union[dict, list], token: int) -> None:
@@ -95,7 +95,7 @@ class FileOutputter(_BaseDataOutputter):
         :param token: an identifier for the current session, to ensure that separate
                       POST / PUT / DELETE requests are recognized as a single version of data
         """
-        with open(f'{self.FILE_BASE}DELETE.json', 'w') as f:
+        with open(f'{self.FILE_BASE}delete.json', 'w') as f:
             f.write(json.dumps(data, indent=4))
 
 

--- a/filter_xml/data_outputter.py
+++ b/filter_xml/data_outputter.py
@@ -16,7 +16,7 @@ class _BaseDataOutputter:
         """
         raise NotImplementedError('Method called on base class; use inherited')
 
-    def insert(self, data: Union[dict, list], token: int) -> None:
+    def insert(self, data: Union[dict, list], token: str) -> None:
         """
         Abstract implementation of method for sending a list of restaurants that should be
         inserted to the API
@@ -29,7 +29,7 @@ class _BaseDataOutputter:
         """
         raise NotImplementedError('Method called on base class; use inherited')
 
-    def update(self, data: Union[dict, list], token: int) -> None:
+    def update(self, data: Union[dict, list], token: str) -> None:
         """
         Abstract implementation of method for sending a list of restaurants that should be
         updated to the API
@@ -42,7 +42,7 @@ class _BaseDataOutputter:
         """
         raise NotImplementedError('Method called on base class; use inherited')
 
-    def delete(self, data: Union[dict, list], token: int) -> None:
+    def delete(self, data: Union[dict, list], token: str) -> None:
         """
         Abstract implementation of method for sending a list of restaurants that should be
         deleted to the API
@@ -65,7 +65,7 @@ class FileOutputter(_BaseDataOutputter):
         """
         return DatabaseOutputter().get()
 
-    def insert(self, data: Union[dict, list], token: int) -> None:
+    def insert(self, data: Union[dict, list], token: str) -> None:
         """
         Output restaurants marked as insert to smiley_json_processed_PUT.json
 
@@ -76,7 +76,7 @@ class FileOutputter(_BaseDataOutputter):
         with open(f'{self.FILE_BASE}insert.json', 'w') as f:
             f.write(json.dumps(data, indent=4))
 
-    def update(self, data: Union[dict, list], token: int) -> None:
+    def update(self, data: Union[dict, list], token: str) -> None:
         """
         Output restaurants marked as update to smiley_json_processed_POST.json
 
@@ -87,7 +87,7 @@ class FileOutputter(_BaseDataOutputter):
         with open(f'{self.FILE_BASE}update.json', 'w') as f:
             f.write(json.dumps(data, indent=4))
 
-    def delete(self, data: Union[dict, list], token: int) -> None:
+    def delete(self, data: Union[dict, list], token: str) -> None:
         """
         Output restaurants marked as delete to smiley_json_processed_DELETE.json
 
@@ -109,7 +109,7 @@ class DatabaseOutputter(_BaseDataOutputter):
         res = requests.get(self.ENDPOINT)
         return json.loads(res.content.decode('utf-8'))
 
-    def insert(self, data: Union[dict, list], token: int) -> None:
+    def insert(self, data: Union[dict, list], token: str) -> None:
         """
         Send restaurants marked as insert to API
 
@@ -127,7 +127,7 @@ class DatabaseOutputter(_BaseDataOutputter):
             print('Failed to send data to database, writing to file instead')
             FileOutputter().insert(data, token)
 
-    def update(self, data: Union[dict, list], token: int) -> None:
+    def update(self, data: Union[dict, list], token: str) -> None:
         """
         Send restaurants marked as update to API
 
@@ -145,7 +145,7 @@ class DatabaseOutputter(_BaseDataOutputter):
             print('Failed to send data to database, writing to file instead')
             FileOutputter().update(data, token)
 
-    def delete(self, data: Union[dict, list], token: int) -> None:
+    def delete(self, data: Union[dict, list], token: str) -> None:
         """
         Send restaurants marked as delete to API
 

--- a/filter_xml/data_outputter.py
+++ b/filter_xml/data_outputter.py
@@ -21,6 +21,10 @@ class _BaseDataOutputter:
         Abstract implementation of method for sending a list of restaurants that should be
         inserted to the API
 
+        :param data: a list of restaurants or a single restaurant
+        :param token: an identifier for the current session, to ensure that separate
+                      POST / PUT / DELETE requests are recognized as a single version of data
+
         Should be overridden in inherited classes
         """
         raise NotImplementedError('Method called on base class; use inherited')
@@ -30,6 +34,10 @@ class _BaseDataOutputter:
         Abstract implementation of method for sending a list of restaurants that should be
         updated to the API
 
+        :param data: a list of restaurants or a single restaurant
+        :param token: an identifier for the current session, to ensure that separate
+                      POST / PUT / DELETE requests are recognized as a single version of data
+
         Should be overridden in inherited classes
         """
         raise NotImplementedError('Method called on base class; use inherited')
@@ -38,6 +46,10 @@ class _BaseDataOutputter:
         """
         Abstract implementation of method for sending a list of restaurants that should be
         deleted to the API
+
+        :param data: a list of restaurants or a single restaurant
+        :param token: an identifier for the current session, to ensure that separate
+                      POST / PUT / DELETE requests are recognized as a single version of data
 
         Should be overridden in inherited classes
         """

--- a/filter_xml/data_outputter.py
+++ b/filter_xml/data_outputter.py
@@ -60,17 +60,41 @@ class FileOutputter(_BaseDataOutputter):
     FILE_BASE = 'smiley_json_processed_'
 
     def get(self) -> list:
-        pass
+        """
+        Retrieve sample restaurants from file
+        """
+        raise NotImplementedError('Method not implemented for FileOutputter')
 
     def insert(self, data: Union[dict, list], token: int) -> None:
+        """
+        Output restaurants marked as insert to smiley_json_processed_PUT.json
+
+        :param data: a list of restaurants or a single restaurant
+        :param token: an identifier for the current session, to ensure that separate
+                      POST / PUT / DELETE requests are recognized as a single version of data
+        """
         with open(f'{self.FILE_BASE}PUT.json', 'w') as f:
             f.write(json.dumps(data, indent=4))
 
     def update(self, data: Union[dict, list], token: int) -> None:
+        """
+        Output restaurants marked as update to smiley_json_processed_POST.json
+
+        :param data: a list of restaurants or a single restaurant
+        :param token: an identifier for the current session, to ensure that separate
+                      POST / PUT / DELETE requests are recognized as a single version of data
+        """
         with open(f'{self.FILE_BASE}POST.json', 'w') as f:
             f.write(json.dumps(data, indent=4))
 
     def delete(self, data: Union[dict, list], token: int) -> None:
+        """
+        Output restaurants marked as delete to smiley_json_processed_DELETE.json
+
+        :param data: a list of restaurants or a single restaurant
+        :param token: an identifier for the current session, to ensure that separate
+                      POST / PUT / DELETE requests are recognized as a single version of data
+        """
         with open(f'{self.FILE_BASE}DELETE.json', 'w') as f:
             f.write(json.dumps(data, indent=4))
 
@@ -79,10 +103,20 @@ class DatabaseOutputter(_BaseDataOutputter):
     ENDPOINT = 'https://127.0.0.1/admin/load'
 
     def get(self) -> list:
+        """
+        Retrieve all current restaurants from the API
+        """
         res = requests.get(self.ENDPOINT)
         return json.loads(res.content.decode('utf-8'))
 
     def insert(self, data: Union[dict, list], token: int) -> None:
+        """
+        Send restaurants marked as insert to API
+
+        :param data: a list of restaurants or a single restaurant
+        :param token: an identifier for the current session, to ensure that separate
+                      POST / PUT / DELETE requests are recognized as a single version of data
+        """
         put_data = {
             'timestamp': token,
             'data': data
@@ -94,6 +128,13 @@ class DatabaseOutputter(_BaseDataOutputter):
             FileOutputter().insert(data, token)
 
     def update(self, data: Union[dict, list], token: int) -> None:
+        """
+        Send restaurants marked as update to API
+
+        :param data: a list of restaurants or a single restaurant
+        :param token: an identifier for the current session, to ensure that separate
+                      POST / PUT / DELETE requests are recognized as a single version of data
+        """
         post_data = {
             'timestamp': token,
             'data': data
@@ -105,6 +146,13 @@ class DatabaseOutputter(_BaseDataOutputter):
             FileOutputter().update(data, token)
 
     def delete(self, data: Union[dict, list], token: int) -> None:
+        """
+        Send restaurants marked as delete to API
+
+        :param data: a list of restaurants or a single restaurant
+        :param token: an identifier for the current session, to ensure that separate
+                      POST / PUT / DELETE requests are recognized as a single version of data
+        """
         delete_data = {
             'timestamp': token,
             'data': data

--- a/filter_xml/data_processor.py
+++ b/filter_xml/data_processor.py
@@ -1,5 +1,7 @@
-from filter_xml.data_outputter import BaseDataOutputter
 import time
+from datetime import datetime
+from filter_xml.config import FilterXMLConfig
+from filter_xml.data_outputter import _BaseDataOutputter
 from filter_xml.temp_file import TempFile
 from filter_xml.prev_processed_file import PrevProcessedFile
 from filter_xml.cvr import get_cvr_handler, FindSmileyHandler
@@ -11,7 +13,7 @@ class DataProcessor:
     Responsible for processing the data in smiley json file
     """
 
-    def __init__(self, sample_size: int, skip_scrape: bool, outputter: BaseDataOutputter) -> None:
+    def __init__(self, sample_size: int, skip_scrape: bool, outputter: _BaseDataOutputter) -> None:
         self._cvr_handler = get_cvr_handler()
         self._smiley_handler = FindSmileyHandler()
         self._sample_size = sample_size
@@ -41,6 +43,8 @@ class DataProcessor:
 
         Once data has been processed, keys are renamed. Cf. the translation map in _rename_keys()
         """
+        # TODO: use outputter.get to get all restaurants from database
+
         temp_file = TempFile()
 
         res = temp_file.get_all()
@@ -101,7 +105,10 @@ class DataProcessor:
 
         res = self._rename_keys(res)
 
-        self._outputter.write(res)
+        token = datetime.now().strftime(FilterXMLConfig.iso_fmt())
+
+        # TODO: split output into outputter.insert, -.update, and -.delete
+        self._outputter.insert(res, token)
 
     @ staticmethod
     def _has_cvr(row: dict) -> bool:


### PR DESCRIPTION
Changed the data outputters to use four different methods: `get, insert, update, delete`. For both file and database, `get` will retrieve all restaurants from the database. For the remaining three: database will send to the API endpoint, and file will write to separate files.

Each of `insert, update, delete` will expect a token used to connect the three calls to a single version in the API. This token is a `datetime` string formatted in accordance to the ISO8601 standard.

For now the write call in the data processing bit has been changed to `insert` with a TODO for updating once the diff has been implemented. I also added a TODO for using the `get` call to retrieve all restaurants.