### PR TITLE
Add diff

### DIFF
--- a/filter_xml/data_processor.py
+++ b/filter_xml/data_processor.py
@@ -186,8 +186,8 @@ class DataProcessor:
     def has_update(new: dict, old: dict):
         comp_keys = ['cvrnr', 'pnr', 'region', 'industry_code', 'industry_text', 'start_date',
                      'city', 'elite_smiley', 'geo_lat', 'geo_lng', 'franchise_name',
-                     'niche_industry', 'url', 'address', 'name', 'name_seq_nr', 'zip_code',
-                     'ad_protection', 'company_type']
+                     'niche_industry', 'url', 'address', 'name', 'zip_code', 'ad_protection',
+                     'company_type']
         smiley_keys = ['report_id', 'smiley', 'date']
 
         for k in comp_keys:

--- a/filter_xml/data_processor.py
+++ b/filter_xml/data_processor.py
@@ -157,6 +157,12 @@ class DataProcessor:
         return self._has_pnr(restaurant) and self._has_cvr(restaurant)
 
     def create_diff(self, res: list) -> tuple:
+        """
+        Construct the difference in data cf. the current contents of the database on the API.
+
+        :param res: the list of new data
+        :return: a tuple of the three types of differences, (insert, update, delete)
+        """
         current_db = self._outputter.get()
         current_ids = {x['name_seq_nr'] for x in current_db}
         res_ids = {x['name_seq_nr'] for x in res}
@@ -173,7 +179,11 @@ class DataProcessor:
 
         return insert, update, list(delete_ids)
 
-    def check_rows_for_updates(self, ids: set, new: dict, old: dict):
+    def check_rows_for_updates(self, ids: set, new: dict, old: dict) -> list[dict]:
+        """
+        Compare each row of new data with their corresponding old row. Used to check for updates
+        in data.
+        """
         out = []
 
         for id_ in ids:
@@ -183,7 +193,10 @@ class DataProcessor:
         return out
 
     @staticmethod
-    def has_update(new: dict, old: dict):
+    def has_update(new: dict, old: dict) -> bool:
+        """
+        Key-wise comparison of a single row of data
+        """
         comp_keys = ['cvrnr', 'pnr', 'region', 'industry_code', 'industry_text', 'start_date',
                      'city', 'elite_smiley', 'geo_lat', 'geo_lng', 'franchise_name',
                      'niche_industry', 'url', 'address', 'name', 'zip_code', 'ad_protection',

--- a/filter_xml/data_processor.py
+++ b/filter_xml/data_processor.py
@@ -158,8 +158,8 @@ class DataProcessor:
 
     def create_diff(self, res: list) -> tuple:
         current_db = self._outputter.get()
-        current_ids = {[x['name_seq_nr'] for x in current_db]}
-        res_ids = {[x['name_seq_nr'] for x in res]}
+        current_ids = {x['name_seq_nr'] for x in current_db}
+        res_ids = {x['name_seq_nr'] for x in res}
 
         res_by_key = {x['name_seq_nr']: x for x in res}
         current_by_key = {x['name_seq_nr']: x for x in current_db}
@@ -171,7 +171,7 @@ class DataProcessor:
         insert = [res_by_key[x] for x in insert_ids]
         update = self.check_rows_for_updates(update_ids, res_by_key, current_by_key)
 
-        return insert, update, delete_ids
+        return insert, update, list(delete_ids)
 
     def check_rows_for_updates(self, ids: set, new: dict, old: dict):
         out = []

--- a/filter_xml/data_processor.py
+++ b/filter_xml/data_processor.py
@@ -179,7 +179,7 @@ class DataProcessor:
 
         return insert, update, list(delete_ids)
 
-    def check_rows_for_updates(self, ids: set, new: dict, old: dict) -> list[dict]:
+    def check_rows_for_updates(self, ids: set, new: dict, old: dict) -> list:
         """
         Compare each row of new data with their corresponding old row. Used to check for updates
         in data.


### PR DESCRIPTION
Implements behaviour to check for diffs in the data cf. the previous data from the database. The diffs are then sent to the relevant endpoint in the API, or written to separate files.

The diffs are defined as:
- `insert`: the set difference between the new and old data
- `delete`: the set difference between the old and new data
- `update`: any row with **any** changed field in the set intersection between the new and old data