### PR TITLE
Minor issue fixes

### DIFF
--- a/filter_xml/catalog.py
+++ b/filter_xml/catalog.py
@@ -81,8 +81,8 @@ class Restaurant:
                                for x in cls.REPORT_KEYS if row[x[0]]]
         self.city = row['By']
         self.elite_smiley = row['Elite_Smiley']
-        self.geo_lat = float(row['Geo_Lat']) if row['Geo_Lat'] else None
-        self.geo_lng = float(row['Geo_Lng']) if row['Geo_Lng'] else None
+        self.geo_lat = row['Geo_Lat'] if row['Geo_Lat'] else None
+        self.geo_lng = row['Geo_Lng'] if row['Geo_Lng'] else None
         self.niche_industry = row['Pixibranche']
         self.url = row['URL']
         self.address = row['adresse1']
@@ -112,11 +112,11 @@ class Restaurant:
         self.industry_text = row['industry_text']
         self.start_date = datetime.strptime(row['start_date'], FilterXMLConfig.iso_fmt())
         self.smiley_reports = [SmileyReport.from_json(report)
-                               for report in json.loads(row['smiley_reports'])]
+                               for report in row['smiley_reports']]
         self.city = row['city']
         self.elite_smiley = row['elite_smiley']
-        self.geo_lat = float(row['geo_lat']) if row['geo_lat'] else None
-        self.geo_lng = float(row['geo_lng']) if row['geo_lng'] else None
+        self.geo_lat = row['geo_lat'] if row['geo_lat'] else None
+        self.geo_lng = row['geo_lng'] if row['geo_lng'] else None
         self.niche_industry = row['niche_industry']
         self.url = row['url']
         self.address = row['address']

--- a/filter_xml/catalog.py
+++ b/filter_xml/catalog.py
@@ -56,9 +56,10 @@ class Restaurant:
             if getattr(self, k) != getattr(other, k):
                 return False
 
-            for new, old in zip(self.smiley_reports, other.smiley_reports):
-                if new != old:
-                    return False
+        for new, old in zip(self.smiley_reports, other.smiley_reports):
+            if new != old:
+                return False
+
         return True
 
     @classmethod

--- a/filter_xml/catalog.py
+++ b/filter_xml/catalog.py
@@ -134,7 +134,7 @@ class Restaurant:
         """
         ISO-8601 formatted start date string property
         """
-        return self.start_date.strftime(FilterXMLConfig.iso_fmt())
+        return self.start_date.strftime(FilterXMLConfig.iso_fmt()) if self.start_date else ''
 
     def is_valid_production_unit(self) -> bool:
         """

--- a/filter_xml/catalog.py
+++ b/filter_xml/catalog.py
@@ -81,8 +81,8 @@ class Restaurant:
                                for x in cls.REPORT_KEYS if row[x[0]]]
         self.city = row['By']
         self.elite_smiley = row['Elite_Smiley']
-        self.geo_lat = row['Geo_Lat'] if row['Geo_Lat'] else None
-        self.geo_lng = row['Geo_Lng'] if row['Geo_Lng'] else None
+        self.geo_lat = float(row['Geo_Lat']) if row['Geo_Lat'] else None
+        self.geo_lng = float(row['Geo_Lng']) if row['Geo_Lng'] else None
         self.niche_industry = row['Pixibranche']
         self.url = row['URL']
         self.address = row['adresse1']
@@ -115,8 +115,8 @@ class Restaurant:
                                for report in row['smiley_reports']]
         self.city = row['city']
         self.elite_smiley = row['elite_smiley']
-        self.geo_lat = row['geo_lat'] if row['geo_lat'] else None
-        self.geo_lng = row['geo_lng'] if row['geo_lng'] else None
+        self.geo_lat = float(row['geo_lat']) if row['geo_lat'] else None
+        self.geo_lng = float(row['geo_lng']) if row['geo_lng'] else None
         self.niche_industry = row['niche_industry']
         self.url = row['url']
         self.address = row['address']

--- a/filter_xml/cvr.py
+++ b/filter_xml/cvr.py
@@ -80,9 +80,11 @@ class CVRHandlerCVRAPI(CVRHandlerBase):
         res = get(self.URL, params=params, headers=headers)
         content = json.loads(res.content.decode('utf-8'))
 
-        if content:
+        if res.status_code == 200:
             for appender in self.appenders:
                 data = appender(content, data)
+        else:
+            print(f'Skipping restaurant with p-nr {data.pnr}: record not found remotely')
 
         return super().collect_data(data)
 

--- a/filter_xml/data_outputter.py
+++ b/filter_xml/data_outputter.py
@@ -143,10 +143,10 @@ class DatabaseOutputter(_BaseDataOutputter):
             'timestamp': token,
             'data': data
         }
-        res = requests.put(self.ENDPOINT, json=put_data)
+        res = requests.post(self.ENDPOINT, json=put_data)
 
         if res.status_code != 200:
-            print('Failed to send data to database, writing to file instead')
+            print('Failed to send insert data to database, writing to file instead')
             FileOutputter().insert(data, token)
 
     def update(self, data: Union[dict, list], token: str) -> None:
@@ -161,10 +161,10 @@ class DatabaseOutputter(_BaseDataOutputter):
             'timestamp': token,
             'data': data
         }
-        res = requests.post(self.ENDPOINT, json=post_data)
+        res = requests.put(self.ENDPOINT, json=post_data)
 
         if res.status_code != 200:
-            print('Failed to send data to database, writing to file instead')
+            print('Failed to send update data to database, writing to file instead')
             FileOutputter().update(data, token)
 
     def delete(self, data: Union[dict, list], token: str) -> None:
@@ -182,7 +182,7 @@ class DatabaseOutputter(_BaseDataOutputter):
         res = requests.delete(self.ENDPOINT, json=delete_data)
 
         if res.status_code != 200:
-            print('Failed to send data to database, writing to file instead')
+            print('Failed to send delete data to database, writing to file instead')
             FileOutputter().delete(data, token)
 
 

--- a/filter_xml/data_outputter.py
+++ b/filter_xml/data_outputter.py
@@ -143,7 +143,7 @@ class DatabaseOutputter(_BaseDataOutputter):
             'timestamp': token,
             'data': data
         }
-        res = requests.put(self.ENDPOINT, json=json.dumps(put_data))
+        res = requests.put(self.ENDPOINT, json=put_data)
 
         if res.status_code != 200:
             print('Failed to send data to database, writing to file instead')
@@ -161,7 +161,7 @@ class DatabaseOutputter(_BaseDataOutputter):
             'timestamp': token,
             'data': data
         }
-        res = requests.post(self.ENDPOINT, json=json.dumps(post_data))
+        res = requests.post(self.ENDPOINT, json=post_data)
 
         if res.status_code != 200:
             print('Failed to send data to database, writing to file instead')
@@ -179,7 +179,7 @@ class DatabaseOutputter(_BaseDataOutputter):
             'timestamp': token,
             'data': data
         }
-        res = requests.delete(self.ENDPOINT, json=json.dumps(delete_data))
+        res = requests.delete(self.ENDPOINT, json=delete_data)
 
         if res.status_code != 200:
             print('Failed to send data to database, writing to file instead')

--- a/filter_xml/data_outputter.py
+++ b/filter_xml/data_outputter.py
@@ -143,7 +143,7 @@ class DatabaseOutputter(_BaseDataOutputter):
             'timestamp': token,
             'data': data
         }
-        res = requests.put(self.ENDPOINT, data=put_data)
+        res = requests.put(self.ENDPOINT, json=json.dumps(put_data))
 
         if res.status_code != 200:
             print('Failed to send data to database, writing to file instead')
@@ -161,7 +161,7 @@ class DatabaseOutputter(_BaseDataOutputter):
             'timestamp': token,
             'data': data
         }
-        res = requests.post(self.ENDPOINT, data=post_data)
+        res = requests.post(self.ENDPOINT, json=json.dumps(post_data))
 
         if res.status_code != 200:
             print('Failed to send data to database, writing to file instead')
@@ -179,7 +179,7 @@ class DatabaseOutputter(_BaseDataOutputter):
             'timestamp': token,
             'data': data
         }
-        res = requests.delete(self.ENDPOINT, data=delete_data)
+        res = requests.delete(self.ENDPOINT, json=json.dumps(delete_data))
 
         if res.status_code != 200:
             print('Failed to send data to database, writing to file instead')

--- a/filter_xml/data_outputter.py
+++ b/filter_xml/data_outputter.py
@@ -126,7 +126,7 @@ class DatabaseOutputter(_BaseDataOutputter):
             res = requests.get(self.ENDPOINT, timeout=4)
             if res.status_code == 200:
                 catalog.add_many([Restaurant.from_json(row)
-                                  for row in json.loads(res.content.decode('utf-8'))])
+                                  for row in res.json()])
         except ConnectionError:
             print('Failed to connect to API')
         return catalog
@@ -139,6 +139,9 @@ class DatabaseOutputter(_BaseDataOutputter):
         :param token: an identifier for the current session, to ensure that separate
                       POST / PUT / DELETE requests are recognized as a single version of data
         """
+        if len(data) == 0:
+            return
+
         put_data = {
             'timestamp': token,
             'data': data
@@ -157,6 +160,9 @@ class DatabaseOutputter(_BaseDataOutputter):
         :param token: an identifier for the current session, to ensure that separate
                       POST / PUT / DELETE requests are recognized as a single version of data
         """
+        if len(data) == 0:
+            return
+
         post_data = {
             'timestamp': token,
             'data': data
@@ -175,6 +181,9 @@ class DatabaseOutputter(_BaseDataOutputter):
         :param token: an identifier for the current session, to ensure that separate
                       POST / PUT / DELETE requests are recognized as a single version of data
         """
+        if len(data) == 0:
+            return
+
         delete_data = {
             'timestamp': token,
             'data': data

--- a/filter_xml/data_processor.py
+++ b/filter_xml/data_processor.py
@@ -89,7 +89,8 @@ class DataProcessor:
                 total_rows -= 1
 
             if self._sample_size:
-                print(f'Collected {res.catalog_size} of {self._sample_size} samples')
+                if row_kept:
+                    print(f'Collected {res.catalog_size} of {self._sample_size} samples')
             else:
                 print(f'{total_rows - res.catalog_size} rows to go')
 

--- a/filter_xml/data_processor.py
+++ b/filter_xml/data_processor.py
@@ -95,12 +95,12 @@ class DataProcessor:
 
             row_index += 1
 
-        temp_file.close()
-        Blacklist.close_file()
-
         token = datetime.now().strftime(FilterXMLConfig.iso_fmt())
         res.setup_diff(self._outputter.get())
 
         self._outputter.insert(res.insert_set(), token)
         self._outputter.update(res.update_set(), token)
         self._outputter.delete(res.delete_set(), token)
+
+        temp_file.close()
+        Blacklist.close_file()

--- a/filter_xml/data_processor.py
+++ b/filter_xml/data_processor.py
@@ -78,10 +78,9 @@ class DataProcessor:
 
                         res.add(restaurant)
                         row_kept = True
+                        temp_file.add_data(restaurant)
                     else:
                         Blacklist.add(restaurant)
-
-                    temp_file.add_data(restaurant)
 
             # if any check resulted in a row skip, decrement the total row count
             # for terminal output purposes

--- a/filter_xml/temp_file.py
+++ b/filter_xml/temp_file.py
@@ -56,6 +56,7 @@ class TempFile:
         reader = csv.DictReader(self.__file, delimiter=";")
         out = dict()
         for entry in reader:
+            entry['smiley_reports'] = json.loads(entry['smiley_reports'])
             entry = Restaurant.from_json(entry)
             out[entry.name_seq_nr] = entry
         return out


### PR DESCRIPTION
During a full run I found that there was at least one record in the smiley data that had a **wrong p-number**. Specifically, there is a row with the p-number `1019983028` which does not exist on [cvrapi](https://cvrapi.dk/) - it is very likely that the correct p-number is either `1019983036` or `1015769471`. To circumvent this I added a check on the status code of the response in the data collection of the CVR handler.

In these cases, because we skip getting external info, they will naturally be filtered with the industry code filter. However the start date is also skipped, as such I added a check on the date string property, such that it returns an empty string when we don't have a start date.

In addition, only rows that pass the post-filters are added to the temp file. Previously all rows (even those that didnt pass the post-filters) were added, and as we are retrieving the contents of the temp file as the result on a run after a crash, these bypassed the filters. This should not have any side-effects since they are filtered by the blacklist.

Finally @joandrsn has fixed the format of the data being sent to the API through `DataOutputter`, such that the API can parse the contents.