### PR TITLE
Use todays XML/JSON if they exist

### DIFF
--- a/filter_xml/data_handler.py
+++ b/filter_xml/data_handler.py
@@ -3,7 +3,7 @@ import json
 from filter_xml.data_outputter import get_outputter
 from filter_xml.smiley_extractor import SmileyExtractor
 from filter_xml.data_processor import DataProcessor
-from filter_xml.util import is_file_from_today
+from filter_xml.util import is_file_old
 
 
 class DataHandler:
@@ -17,7 +17,7 @@ class DataHandler:
         smiley_file = kwargs.pop('file', None)
 
         self.smiley_file = smiley_file if smiley_file else self.SMILEY_XML
-        self.should_get_xml = False if smiley_file else is_file_from_today(self.SMILEY_XML)
+        self.should_get_xml = False if smiley_file else is_file_old(self.SMILEY_XML)
 
         self.data_processor = DataProcessor(sample_size, skip_scrape, outputter)
 
@@ -25,7 +25,7 @@ class DataHandler:
         """
             Main runner for collection
         """
-        if is_file_from_today(self.SMILEY_JSON):
+        if not is_file_old(self.SMILEY_JSON):
             with open(self.SMILEY_JSON, 'r') as f:
                 data = json.loads(f.read())
         else:

--- a/filter_xml/data_handler.py
+++ b/filter_xml/data_handler.py
@@ -1,10 +1,14 @@
+import json
+
 from filter_xml.data_outputter import get_outputter
 from filter_xml.smiley_extractor import SmileyExtractor
 from filter_xml.data_processor import DataProcessor
+from filter_xml.util import is_file_from_today
 
 
 class DataHandler:
     SMILEY_XML = 'smiley_xml.xml'
+    SMILEY_JSON = 'smiley_json.json'
 
     def __init__(self, *args, **kwargs) -> None:
         sample_size = kwargs.pop('sample', 0)
@@ -13,7 +17,7 @@ class DataHandler:
         smiley_file = kwargs.pop('file', None)
 
         self.smiley_file = smiley_file if smiley_file else self.SMILEY_XML
-        self.should_get_xml = False if smiley_file else True
+        self.should_get_xml = False if smiley_file else is_file_from_today(self.SMILEY_XML)
 
         self.data_processor = DataProcessor(sample_size, skip_scrape, outputter)
 
@@ -21,6 +25,14 @@ class DataHandler:
         """
             Main runner for collection
         """
-        smiley_extractor = SmileyExtractor(self.smiley_file, self.should_get_xml)
-        data = smiley_extractor.create_smiley_json()
+        if is_file_from_today(self.SMILEY_JSON):
+            with open(self.SMILEY_JSON, 'r') as f:
+                data = json.loads(f.read())
+        else:
+            smiley_extractor = SmileyExtractor(self.smiley_file, self.should_get_xml)
+            data = smiley_extractor.create_smiley_json()
+
+            with open(self.SMILEY_JSON, 'w') as f:
+                f.write(json.dumps(data, indent=4))
+
         self.data_processor.process_smiley_json(data)

--- a/filter_xml/util.py
+++ b/filter_xml/util.py
@@ -1,0 +1,18 @@
+import os
+
+from datetime import datetime
+from pathlib import Path
+
+
+def is_file_from_today(path: str) -> bool:
+    """
+    Check whether or not a file defined by :param path is modified today
+    """
+    if not os.path.isfile(path):
+        return False
+
+    f_stat = Path(path).stat()
+    m_stamp = datetime.fromtimestamp(f_stat.st_mtime)
+    now = datetime.now()
+
+    return now.date() == m_stamp.date()

--- a/filter_xml/util.py
+++ b/filter_xml/util.py
@@ -4,15 +4,15 @@ from datetime import datetime
 from pathlib import Path
 
 
-def is_file_from_today(path: str) -> bool:
+def is_file_old(path: str) -> bool:
     """
     Check whether or not a file defined by :param path is modified today
     """
     if not os.path.isfile(path):
-        return False
+        return True
 
     f_stat = Path(path).stat()
     m_stamp = datetime.fromtimestamp(f_stat.st_mtime)
     now = datetime.now()
 
-    return now.date() == m_stamp.date()
+    return now.date() != m_stamp.date()


### PR DESCRIPTION
Currently the collection of the smiley XML and converting it to a dict/json structure takes a long time,
```
# the time taken for SmileyExtractor.create_smiley_json()
(venv) [badgy@dsk filter_xml]$ time python test.py

real    0m46.094s
user    0m39.937s
sys     0m0.437s
```
This is a *long* time to wait if you are continuously running the script in order to test your changes.

This PR adds a check on the modification date of both `smiley_xml.xml` and `smiley_json.json`. If either file has been modified (i.e., retrieved and/or processed) today, they will be used for subsequent runs. If either file does either not exist or the last modification was a day before today, new ones will be retrieved and processed.