### PR TITLE
Add city fetcher to avoid null's in city name

### DIFF
--- a/filter_xml/cvr.py
+++ b/filter_xml/cvr.py
@@ -320,3 +320,26 @@ class FindSmileyHandler:
                 report.report_id = url.split('?')[1]
 
         return row
+
+
+class ZipcodeFinder:
+    """
+    Handler for fetching the name of city from zipcodes
+    """
+    URL = 'https://dawa.aws.dk/postnumre'
+
+    def collect_data(self, data: Restaurant) -> Restaurant:
+        """
+        """
+        if data.city is not None:
+            return data
+        print(f'Fetching city info on zipcode {data.zip_code}')
+        params = {
+            'nr': data.zip_code
+        }
+        res = get(self.URL, params=params)
+        if res.status_code == 200:
+            data.city = res.json()[0]['navn']
+        else:
+            print(f'Bad response when fetching zipcode: {data.zip_code}')
+        return data

--- a/filter_xml/data_processor.py
+++ b/filter_xml/data_processor.py
@@ -4,7 +4,7 @@ from filter_xml.config import FilterXMLConfig
 from filter_xml.data_outputter import _BaseDataOutputter
 from filter_xml.temp_file import TempFile
 from filter_xml.blacklist import Blacklist
-from filter_xml.cvr import get_cvr_handler, FindSmileyHandler
+from filter_xml.cvr import get_cvr_handler, FindSmileyHandler, ZipcodeFinder
 from filter_xml.filters import PostFilters
 from filter_xml.catalog import RestaurantCatalog
 
@@ -17,6 +17,7 @@ class DataProcessor:
     def __init__(self, sample_size: int, skip_scrape: bool, outputter: _BaseDataOutputter) -> None:
         self._cvr_handler = get_cvr_handler()
         self._smiley_handler = FindSmileyHandler()
+        self._zipcode_finder = ZipcodeFinder()
         self._sample_size = sample_size
         self._skip_scrape = skip_scrape
         self._outputter = outputter
@@ -78,6 +79,7 @@ class DataProcessor:
                     if all([filter_(restaurant) for filter_ in self.post_filters.filters()]):
                         if not self._skip_scrape:
                             restaurant = self._smiley_handler.collect_data(restaurant)
+                            restaurant = self._zipcode_finder.collect_data(restaurant)
 
                         res.add(restaurant)
                         row_kept = True


### PR DESCRIPTION
Some restaurants have `null` in the name of the city.
To combat this, this PR adds a fetcher to lookup the cityname based on the zipcode.

Example of URL:
https://dawa.aws.dk/postnumre?nr=9000

Example of problematic row from the XML:
![image](https://user-images.githubusercontent.com/5766695/116859246-f6c44480-abff-11eb-88e2-0733cbaabbc4.png)
