### PR TITLE
Logging, bug fixes, zip code revamp

### DIFF
--- a/filter_xml/__init__.py
+++ b/filter_xml/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 from argparse import ArgumentParser
 
 from .data_handler import DataHandler
@@ -11,10 +13,24 @@ arg_parser.add_argument('--push', '-p', action='store_true',
                         help='push output to rust server')
 arg_parser.add_argument('--file', '-f', nargs=1, type=str,
                         help='file path for xml to use (default: get from fødevarestyrelsen)')
+arg_parser.add_argument('--clean', '-c', action='store_true',
+                        help='clean all temp files and exit')
 
 
 def run():
     args = arg_parser.parse_args()
+
+    if args.clean:
+        files = ['blacklist.csv', 'temp.csv', 'filter_log.json',
+                 'smiley_json_processed_delete.json', 'smiley_json_processed_insert.json',
+                 'smiley_json_processed_update.json']
+
+        for file in files:
+            print(f'removing file {file}')
+            if os.path.isfile(file):
+                os.remove(file)
+
+        return
 
     dh = DataHandler(
         sample=args.sample,

--- a/filter_xml/catalog.py
+++ b/filter_xml/catalog.py
@@ -112,7 +112,8 @@ class Restaurant:
         self.region = row['region']
         self.industry_code = row['industry_code']
         self.industry_text = row['industry_text']
-        self.start_date = datetime.strptime(row['start_date'], FilterXMLConfig.iso_fmt())
+        self.start_date = datetime.strptime(row['start_date'], FilterXMLConfig.iso_fmt()) \
+            if row['start_date'] else ''
         self.end_date = datetime.strptime(row['end_date'], FilterXMLConfig.iso_fmt()) \
             if row['end_date'] else ''
         self.smiley_reports = [SmileyReport.from_json(report)

--- a/filter_xml/catalog.py
+++ b/filter_xml/catalog.py
@@ -2,7 +2,6 @@
 # so we need to import future annotations to allow this
 # note that __future__ imports must be the first line of the file
 from __future__ import annotations
-import json
 
 from typing import Optional, List, Set, Dict
 from datetime import datetime
@@ -31,6 +30,7 @@ class Restaurant:
         self.industry_code = None  # type: Optional[str]
         self.industry_text = None  # type: Optional[str]
         self.start_date = None  # type: Optional[datetime]
+        self.end_date = None  # type: Optional[datetime]
         self.smiley_reports = []  # type: List[SmileyReport]
         self.city = None  # type: Optional[str]
         self.elite_smiley = None  # type: Optional[str]
@@ -78,6 +78,7 @@ class Restaurant:
         self.industry_code = row['brancheKode']
         self.industry_text = row['branche']
         self.start_date = None
+        self.end_date = None
         self.smiley_reports = [SmileyReport.from_xml(row[x[0]], row[x[1]])
                                for x in cls.REPORT_KEYS if row[x[0]]]
         self.city = row['By']
@@ -112,6 +113,8 @@ class Restaurant:
         self.industry_code = row['industry_code']
         self.industry_text = row['industry_text']
         self.start_date = datetime.strptime(row['start_date'], FilterXMLConfig.iso_fmt())
+        self.end_date = datetime.strptime(row['end_date'], FilterXMLConfig.iso_fmt()) \
+            if row['end_date'] else ''
         self.smiley_reports = [SmileyReport.from_json(report)
                                for report in row['smiley_reports']]
         self.city = row['city']
@@ -137,12 +140,19 @@ class Restaurant:
         """
         return self.start_date.strftime(FilterXMLConfig.iso_fmt()) if self.start_date else ''
 
+    @property
+    def end_date_string(self) -> str:
+        """
+        ISO-8601 formatted start date string property
+        """
+        return self.end_date.strftime(FilterXMLConfig.iso_fmt()) if self.end_date else ''
+
     def is_valid_production_unit(self) -> bool:
         """
         Determines whether or not this Restaurant is a valid production unit by ensuring that
         both CVR- and P-numbers exist
         """
-        return self.cvrnr is not None and self.pnr is not None
+        return bool(self.cvrnr) and bool(self.pnr)
 
     def as_dict(self) -> dict:
         """
@@ -151,6 +161,7 @@ class Restaurant:
         d = self.__dict__.copy()
         d['smiley_reports'] = [report.as_dict() for report in self.smiley_reports]
         d['start_date'] = self.start_date_string
+        d['end_date'] = self.end_date_string
         return d
 
     def has_update(self, old: Restaurant) -> bool:

--- a/filter_xml/cvr.py
+++ b/filter_xml/cvr.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 from filter_xml.config import FilterXMLConfig
 from filter_xml.catalog import Restaurant
+from filter_xml.filters import FilterLog
 
 
 class CVRHandlerBase:
@@ -328,11 +329,17 @@ class ZipcodeFinder:
     """
     URL = 'https://dawa.aws.dk/postnumre'
 
+    def __init__(self):
+        self.log = FilterLog()
+        self.log['null_city'] = 0
+
     def collect_data(self, data: Restaurant) -> Restaurant:
         """
         """
         if data.city is not None:
             return data
+
+        self.log['null_city'] += 1
         print(f'Fetching city info on zipcode {data.zip_code}')
         params = {
             'nr': data.zip_code

--- a/filter_xml/cvr.py
+++ b/filter_xml/cvr.py
@@ -318,7 +318,8 @@ class FindSmileyHandler:
         for tag, report in zip(tags, row.smiley_reports):
             if report:
                 url = tag.attrs['href']
-                report.report_id = url.split('?')[1]
+                # use default if we cant find urls - will yield error page
+                report.report_id = url.split('?')[1] if url else 'Virk'
 
         return row
 

--- a/filter_xml/data_processor.py
+++ b/filter_xml/data_processor.py
@@ -4,7 +4,7 @@ from filter_xml.config import FilterXMLConfig
 from filter_xml.data_outputter import _BaseDataOutputter
 from filter_xml.temp_file import TempFile
 from filter_xml.blacklist import Blacklist
-from filter_xml.cvr import get_cvr_handler, FindSmileyHandler, ZipcodeFinder
+from filter_xml.cvr import get_cvr_handler, FindSmileyHandler
 from filter_xml.filters import PostFilters
 from filter_xml.catalog import RestaurantCatalog
 
@@ -17,7 +17,6 @@ class DataProcessor:
     def __init__(self, sample_size: int, skip_scrape: bool, outputter: _BaseDataOutputter) -> None:
         self._cvr_handler = get_cvr_handler()
         self._smiley_handler = FindSmileyHandler()
-        self._zipcode_finder = ZipcodeFinder()
         self._sample_size = sample_size
         self._skip_scrape = skip_scrape
         self._outputter = outputter
@@ -77,11 +76,6 @@ class DataProcessor:
                     if self.post_filters.filter(restaurant):
                         if not self._skip_scrape:
                             restaurant = self._smiley_handler.collect_data(restaurant)
-                            restaurant = self._zipcode_finder.collect_data(restaurant)
-
-                        # unable to fetch city from zip
-                        if restaurant.city is None:
-                            continue
 
                         res.add(restaurant)
                         row_kept = True

--- a/filter_xml/data_processor.py
+++ b/filter_xml/data_processor.py
@@ -79,6 +79,10 @@ class DataProcessor:
                             restaurant = self._smiley_handler.collect_data(restaurant)
                             restaurant = self._zipcode_finder.collect_data(restaurant)
 
+                        # unable to fetch city from zip
+                        if restaurant.city is None:
+                            continue
+
                         res.add(restaurant)
                         row_kept = True
                         temp_file.add_data(restaurant)

--- a/filter_xml/data_processor.py
+++ b/filter_xml/data_processor.py
@@ -21,8 +21,6 @@ class DataProcessor:
         self._sample_size = sample_size
         self._skip_scrape = skip_scrape
         self._outputter = outputter
-
-        # collect all class methods prefixed by 'filter_'
         self.post_filters = PostFilters()
 
     def process_smiley_json(self, data: RestaurantCatalog) -> None:
@@ -76,7 +74,7 @@ class DataProcessor:
 
                     # check filters to see if we should keep the row
                     # otherwise add it to blacklist so we don't scrape it next time
-                    if all([filter_(restaurant) for filter_ in self.post_filters.filters()]):
+                    if self.post_filters.filter(restaurant):
                         if not self._skip_scrape:
                             restaurant = self._smiley_handler.collect_data(restaurant)
                             restaurant = self._zipcode_finder.collect_data(restaurant)

--- a/filter_xml/data_processor.py
+++ b/filter_xml/data_processor.py
@@ -100,6 +100,8 @@ class DataProcessor:
 
             row_index += 1
 
+        self.post_filters.log_filters()
+
         token = datetime.now().strftime(FilterXMLConfig.iso_fmt())
         res.setup_diff(self._outputter.get())
 

--- a/filter_xml/filters.py
+++ b/filter_xml/filters.py
@@ -1,6 +1,7 @@
 import json
 import os
 
+from datetime import datetime
 from typing import List, Callable, Dict
 from filter_xml.blacklist import Blacklist
 from filter_xml.catalog import Restaurant
@@ -41,7 +42,7 @@ class FilterLog:
 
         with open(self.LOG_FILE, 'r') as f:
             data = json.loads(f.read())
-            return data[key]
+            return data['log'][key]
 
     def __setitem__(self, key: str, value: int):
         """
@@ -52,7 +53,7 @@ class FilterLog:
         with open(self.LOG_FILE, 'r') as f:
             data = json.loads(f.read())
 
-        data[key] = value
+        data['log'][key] = value
 
         with open(self.LOG_FILE, 'w') as f:
             f.write(json.dumps(data, indent=4))
@@ -69,14 +70,14 @@ class FilterLog:
         """
         with open(self.LOG_FILE, 'r') as f:
             data = json.loads(f.read())
-            return key in data.keys()
+            return key in data['log'].keys()
 
     def _create_file(self):
         """
         Create the file and write an empty json structure
         """
         with open(self.LOG_FILE, 'w') as f:
-            f.write(json.dumps({}))
+            f.write(json.dumps({'time': datetime.now(), 'log': {}}))
 
 
 class Filters:

--- a/filter_xml/filters.py
+++ b/filter_xml/filters.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import List, Callable, Dict
 from filter_xml.blacklist import Blacklist
 from filter_xml.catalog import Restaurant
+from filter_xml.config import FilterXMLConfig
 
 
 class FilterLog:
@@ -77,7 +78,10 @@ class FilterLog:
         Create the file and write an empty json structure
         """
         with open(self.LOG_FILE, 'w') as f:
-            f.write(json.dumps({'time': datetime.now(), 'log': {}}))
+            f.write(json.dumps({
+                'time': datetime.now().strftime(FilterXMLConfig.iso_fmt()),
+                'log': {}
+            }))
 
 
 class Filters:
@@ -168,8 +172,13 @@ class PostFilters(Filters):
     """
 
     LOG = {
-        'industry_code': 0
+        'industry_code': 0,
+        'end_date': 0
     }
+
+    def __init__(self):
+        self.LOGGER['industry_code'] = 0
+        self.LOGGER['end_date'] = 0
 
     @classmethod
     def filter_industry_codes(cls, data: Restaurant) -> bool:
@@ -179,5 +188,16 @@ class PostFilters(Filters):
         include_codes = ['561010', '561020', '563000']
         res = data.industry_code in include_codes
         if not res:
-            cls.LOG['industry_code'] += 1
+            cls.LOGGER['industry_code'] += 1
+        return res
+
+    @classmethod
+    def filter_end_date(cls, data: Restaurant) -> bool:
+        """
+        Checks if row 'data' has an end date
+        """
+        res = not data.end_date
+        if not res:
+            print(f'end date: {data.end_date}, pnr: {data.pnr}')
+            cls.LOGGER['end_date'] += 1
         return res

--- a/filter_xml/filters.py
+++ b/filter_xml/filters.py
@@ -97,6 +97,11 @@ class Filters:
         for filter_name, count in self.LOG.items():
             print(f'{filter_name}: {count}')
 
+    @classmethod
+    def log_filters(cls):
+        for key, value in cls.LOG.items():
+            cls.LOGGER[key] = value
+
 
 class PreFilters(Filters):
     """
@@ -114,16 +119,6 @@ class PreFilters(Filters):
         'null_coordinates': 0,
         'blacklisted': 0
     }
-
-    def __init__(self):
-        self.LOGGER['null_control'] = 0
-        self.LOGGER['null_coordinates'] = 0
-        self.LOGGER['blacklisted'] = 0
-
-    @classmethod
-    def log_pre_filters(cls):
-        for key, value in cls.LOG.items():
-            cls.LOGGER[key] = value
 
     @ classmethod
     def filter_null_control(cls, data: Restaurant) -> bool:
@@ -165,8 +160,9 @@ class PostFilters(Filters):
     cls.LOGGER[key] here.
     """
 
-    def __init__(self):
-        self.LOGGER['industry_code'] = 0
+    LOG = {
+        'industry_code': 0
+    }
 
     @classmethod
     def filter_industry_codes(cls, data: Restaurant) -> bool:
@@ -175,7 +171,6 @@ class PostFilters(Filters):
         """
         include_codes = ['561010', '561020', '563000']
         res = data.industry_code in include_codes
-        print(f'valid industry code: {res}')
         if not res:
-            cls.LOGGER['industry_code'] += 1
+            cls.LOG['industry_code'] += 1
         return res

--- a/filter_xml/filters.py
+++ b/filter_xml/filters.py
@@ -86,7 +86,7 @@ class Filters:
     LOG = {}  # type: Dict[str, int]
     LOGGER = FilterLog()
 
-    def filters(self) -> List[Callable]:
+    def _filters(self) -> List[Callable]:
         return [getattr(self.__class__, fun)
                 for fun in dir(self.__class__)
                 if callable(getattr(self.__class__, fun))
@@ -101,6 +101,12 @@ class Filters:
     def log_filters(cls):
         for key, value in cls.LOG.items():
             cls.LOGGER[key] = value
+
+    def filter(self, restaurant: Restaurant):
+        for f in self._filters():
+            if not f(restaurant):
+                return False
+        return True
 
 
 class PreFilters(Filters):

--- a/filter_xml/smiley_extractor.py
+++ b/filter_xml/smiley_extractor.py
@@ -36,7 +36,7 @@ class SmileyExtractor:
 
             catalog.add(new_obj)
 
-        self.pre_filters.log_pre_filters()
+        self.pre_filters.log_filters()
         return catalog
 
     def _retrieve_smiley_data(self) -> None:

--- a/filter_xml/smiley_extractor.py
+++ b/filter_xml/smiley_extractor.py
@@ -31,7 +31,7 @@ class SmileyExtractor:
             new_obj = Restaurant.from_xml({col.tag: col.text for col in row})
 
             # run all pre filters and skip if all does not pass
-            if not all([filter_(new_obj) for filter_ in self.pre_filters.filters()]):
+            if not self.pre_filters.filter(new_obj):
                 continue
 
             catalog.add(new_obj)

--- a/test/test_temp_file.py
+++ b/test/test_temp_file.py
@@ -73,4 +73,4 @@ class TempFileTest(unittest.TestCase):
 
         data = self.temp_file.get_all()
         
-        self.assertEqual(data.catalog[0].start_date, None)
+        self.assertEqual(data.catalog[0].start_date, '')


### PR DESCRIPTION
Additions:
- 48de17b - added a `--clean, -c` arg that removes all files that are used during run (i.e., blacklist, temp, filter log, and processed smiley jsons)
- dae085e - added a timestamp to log
- f38320e - added an end date filter that removes closed companies
- d203eee - changed zip code handler to be a map of `zip_code: city_name` pairs, instead of requesting every time
- Additional logging:
    - whenever a city is null
    - whenever a city is null and its zip code is invalid
- 3714f76 - use `Virk` as a fallback ID for reports when we can't retrieve the actual ID from findsmiley
    - this is done due to [this](https://www.findsmiley.dk/665539) page. At current time the page for [this](https://www.findsmiley.dk/Sider/Search.aspx?k=37829471) company is fucked.